### PR TITLE
Prevent CI builds from happening twice for  PR

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,12 @@
 name: Regression Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
From: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662