### PR TITLE
Fix AxiStreamFrame default for self.byte_lanes from 1 to all.

### DIFF
--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -287,7 +287,7 @@ class AxiStreamBase(Reset):
         self.queue_occupancy_frames = 0
 
         self.width = len(self.bus.tdata)
-        self.byte_lanes = 1
+        self.byte_lanes = self.width // 8
 
         if self._valid_init is not None and hasattr(self.bus, "tvalid"):
             self.bus.tvalid.setimmediatevalue(self._valid_init)


### PR DESCRIPTION
If I connect a AXIS source to an AXIS sink, the #byte_lanes is incorrectly 1 rather than all lanes enabled.
```
self.source = AxiStreamSource(AxiStreamBus.from_prefix(dut, "sink"), dut.clk, dut.reset)
```

Root cause is AxiStreamFrame assumes byte width 1 without TKEEP, but it should default to self.width // 8 because the AXIS specification mentions "when TKEEP is absent, TKEEP defaults to all bits HIGH" and "The width of the data payload is an integer number of bytes."

Fix: `https://github.com/alexforencich/cocotbext-axi/blob/master/cocotbext/axi/axis.py#L290`

```
-self.byte_lanes = 1
+self.byte_lanes = self.width // 8
```

(Note that if byte_lanes is specified, or the byte_size is overridden, the existing code correctly calculates self.byte_lanes.)

Relevant AXIS Specification:
https://developer.arm.com/documentation/ihi0051/a/Default-Signaling-Requirements/Default-value-signaling/Optional-TKEEP-and-TSTRB?lang=en

Signed-off-by: Leon Woestenberg <leon@sidebranch.com>