### PR TITLE
Optional deinterleaving in AxisStreamSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ To receive data with an `AxiStreamSink` or `AxiStreamMonitor`, call `recv()`/`re
 
     data = await axis_sink.recv()
 
+To de-interleave receive data, for example the `deinterleave` parameter can be set on the `AxiStreamSink` constructor. This causes calls to `read()` and `recv()` to return data sorted by `tid` ot `tdest`, returned in order of transaction completion time.
+
+    axis_sink = AxiStreamSink(AxiStreamBus.from_prefix(dut, "m_axis"), dut.clk, dut.rst, deinterleave="tid")
+    data = await axis_sink.recv()
+
 #### Signals
 
 * `tdata`: data, required


### PR DESCRIPTION
Where the dut may output interleaved transactions, the current sink returns frames delimited by tlast, but contains data from multiple transactions.

This commit adds an opt in parameter which allows transactions to be sorted, prior to insertion in the rx queue. This causes recv() / read() calls to return frames containing deinterleaved transactions, with the return order determined by occurrence of tlast within each transaction.

If tlast is not present, this has no effect