### PR TITLE
Async Pause Generator Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ __pycache__/
 
 
 .tox
-sim_build_*
-.coverage
+**/sim_build*
+.coverage*

--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -417,7 +417,6 @@ class AxiStreamPause:
         if inspect.isasyncgenfunction(self._pause_generator):
             async for val in self._pause_generator():
                 self.pause = val
-                await clock_edge_event
         else:
             for val in self._pause_generator:
                 self.pause = val

--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 """
 
 import logging
+import inspect
 
 import cocotb
 from cocotb.queue import Queue, QueueFull
@@ -413,9 +414,14 @@ class AxiStreamPause:
     async def _run_pause(self):
         clock_edge_event = RisingEdge(self.clock)
 
-        for val in self._pause_generator:
-            self.pause = val
-            await clock_edge_event
+        if inspect.isasyncgenfunction(self._pause_generator):
+            async for val in self._pause_generator():
+                self.pause = val
+                await clock_edge_event
+        else:
+            for val in self._pause_generator:
+                self.pause = val
+                await clock_edge_event
 
 
 class AxiStreamSource(AxiStreamBase, AxiStreamPause):

--- a/cocotbext/axi/stream.py
+++ b/cocotbext/axi/stream.py
@@ -201,7 +201,6 @@ class StreamPause:
         if inspect.isasyncgenfunction(self._pause_generator):
             async for val in self._pause_generator():
                 self.pause = val
-                await clock_edge_event
         else:
             for val in self._pause_generator:
                 self.pause = val

--- a/cocotbext/axi/stream.py
+++ b/cocotbext/axi/stream.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 """
 
 import logging
+import inspect
 
 import cocotb
 from cocotb.queue import Queue, QueueFull
@@ -197,9 +198,14 @@ class StreamPause:
     async def _run_pause(self):
         clock_edge_event = RisingEdge(self.clock)
 
-        for val in self._pause_generator:
-            self.pause = val
-            await clock_edge_event
+        if inspect.isasyncgenfunction(self._pause_generator):
+            async for val in self._pause_generator():
+                self.pause = val
+                await clock_edge_event
+        else:
+            for val in self._pause_generator:
+                self.pause = val
+                await clock_edge_event
 
 
 class StreamSource(StreamBase, StreamPause):

--- a/tests/axi/test_axi.py
+++ b/tests/axi/test_axi.py
@@ -296,6 +296,13 @@ def cycle_pause():
     return itertools.cycle([1, 1, 1, 0])
 
 
+def cycle_random():
+    async def ret():
+        while True:
+            yield bool(random.getrandbits(1))
+    return ret
+
+
 if cocotb.SIM_NAME:
 
     data_width = len(cocotb.top.axi_wdata)
@@ -305,8 +312,8 @@ if cocotb.SIM_NAME:
     for test in [run_test_write, run_test_read]:
 
         factory = TestFactory(test)
-        factory.add_option("idle_inserter", [None, cycle_pause])
-        factory.add_option("backpressure_inserter", [None, cycle_pause])
+        factory.add_option("idle_inserter", [None, cycle_pause, cycle_random])
+        factory.add_option("backpressure_inserter", [None, cycle_pause, cycle_random])
         factory.add_option("size", [None]+list(range(max_burst_size)))
         factory.generate_tests()
 

--- a/tests/axi/test_axi.py
+++ b/tests/axi/test_axi.py
@@ -300,6 +300,7 @@ def cycle_random():
     async def ret():
         while True:
             yield bool(random.getrandbits(1))
+            await Timer(random.randint(1, 100), 'ns')
     return ret
 
 

--- a/tests/axil/test_axil.py
+++ b/tests/axil/test_axil.py
@@ -285,13 +285,20 @@ def cycle_pause():
     return itertools.cycle([1, 1, 1, 0])
 
 
+def cycle_random():
+    async def ret():
+        while True:
+            yield bool(random.getrandbits(1))
+    return ret
+
+
 if cocotb.SIM_NAME:
 
     for test in [run_test_write, run_test_read]:
 
         factory = TestFactory(test)
-        factory.add_option("idle_inserter", [None, cycle_pause])
-        factory.add_option("backpressure_inserter", [None, cycle_pause])
+        factory.add_option("idle_inserter", [None, cycle_pause, cycle_random])
+        factory.add_option("backpressure_inserter", [None, cycle_pause, cycle_random])
         factory.generate_tests()
 
     for test in [run_test_write_words, run_test_read_words]:

--- a/tests/axil/test_axil.py
+++ b/tests/axil/test_axil.py
@@ -289,6 +289,7 @@ def cycle_random():
     async def ret():
         while True:
             yield bool(random.getrandbits(1))
+            await Timer(random.randint(1, 100), 'ns')
     return ret
 
 

--- a/tests/axis/test_axis.py
+++ b/tests/axis/test_axis.py
@@ -26,6 +26,7 @@ THE SOFTWARE.
 import itertools
 import logging
 import os
+import random
 
 import cocotb_test.simulator
 import pytest
@@ -125,6 +126,13 @@ def cycle_pause():
     return itertools.cycle([1, 1, 1, 0])
 
 
+def cycle_random():
+    async def ret():
+        while True:
+            yield bool(random.getrandbits(1))
+    return ret
+
+
 def size_list():
     data_width = len(cocotb.top.axis_tdata)
     byte_width = data_width // 8
@@ -140,8 +148,8 @@ if cocotb.SIM_NAME:
     factory = TestFactory(run_test)
     factory.add_option("payload_lengths", [size_list])
     factory.add_option("payload_data", [incrementing_payload])
-    factory.add_option("idle_inserter", [None, cycle_pause])
-    factory.add_option("backpressure_inserter", [None, cycle_pause])
+    factory.add_option("idle_inserter", [None, cycle_pause, cycle_random])
+    factory.add_option("backpressure_inserter", [None, cycle_pause, cycle_random])
     factory.generate_tests()
 
 

--- a/tests/axis/test_axis.py
+++ b/tests/axis/test_axis.py
@@ -33,7 +33,7 @@ import pytest
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import RisingEdge
+from cocotb.triggers import RisingEdge, Timer
 from cocotb.regression import TestFactory
 
 from cocotbext.axi import AxiStreamFrame, AxiStreamBus, AxiStreamSource, AxiStreamSink, AxiStreamMonitor
@@ -130,6 +130,7 @@ def cycle_random():
     async def ret():
         while True:
             yield bool(random.getrandbits(1))
+            await Timer(random.randint(1, 100), 'ns')
     return ret
 
 


### PR DESCRIPTION
Added support for async pause generators. This enables you to use things like
```
async def pause_generator():
    while True:
        yield bool(random.getrandbits(1))
````
instead of
```
itertools.cycle([True, False])
```
as your AXI pause generators, which can allow for more flexibility.