### PR TITLE
Add support for upcoming cocotb 2.0

### DIFF
--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -519,8 +519,8 @@ class AxiStreamSource(AxiStreamBase, AxiStreamPause):
             await clock_edge_event
 
             # read handshake signals
-            tready_sample = (not has_tready) or self.bus.tready.value
-            tvalid_sample = (not has_tvalid) or self.bus.tvalid.value
+            tready_sample = (not has_tready) or str(self.bus.tready.value) == '1'
+            tvalid_sample = (not has_tvalid) or str(self.bus.tvalid.value) == '1'
 
             if (tready_sample and tvalid_sample) or not tvalid_sample:
                 if not frame and not self.queue.empty():
@@ -689,8 +689,8 @@ class AxiStreamMonitor(AxiStreamBase):
             await clock_edge_event
 
             # read handshake signals
-            tready_sample = (not has_tready) or self.bus.tready.value
-            tvalid_sample = (not has_tvalid) or self.bus.tvalid.value
+            tready_sample = (not has_tready) or str(self.bus.tready.value) == '1'
+            tvalid_sample = (not has_tvalid) or str(self.bus.tvalid.value) == '1'
 
             if tready_sample and tvalid_sample:
                 if not frame:
@@ -712,7 +712,7 @@ class AxiStreamMonitor(AxiStreamBase):
                     if has_tuser:
                         frame.tuser.append(self.bus.tuser.value.integer)
 
-                if not has_tlast or self.bus.tlast.value:
+                if not has_tlast or str(self.bus.tlast.value) == '1':
                     frame.sim_time_end = get_sim_time()
                     self.log.info("RX frame: %s", frame)
 
@@ -790,8 +790,8 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
             await clock_edge_event
 
             # read handshake signals
-            tready_sample = (not has_tready) or self.bus.tready.value
-            tvalid_sample = (not has_tvalid) or self.bus.tvalid.value
+            tready_sample = (not has_tready) or str(self.bus.tready.value) == '1'
+            tvalid_sample = (not has_tvalid) or str(self.bus.tvalid.value) == '1'
 
             if tready_sample and tvalid_sample:
                 if not frame:
@@ -813,7 +813,7 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
                     if has_tuser:
                         frame.tuser.append(self.bus.tuser.value.integer)
 
-                if not has_tlast or self.bus.tlast.value:
+                if not has_tlast or str(self.bus.tlast.value) == '1':
                     frame.sim_time_end = get_sim_time()
                     self.log.info("RX frame: %s", frame)
 

--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -30,6 +30,7 @@ from cocotb.triggers import RisingEdge, Timer, First, Event
 from cocotb.utils import get_sim_time
 from cocotb_bus.bus import Bus
 
+from .compat import apply_binstr
 from .version import __version__
 from .reset import Reset
 
@@ -302,7 +303,7 @@ class AxiStreamBase(Reset):
             if hasattr(self.bus, sig):
                 if self._init_x and sig not in ("tvalid", "tready"):
                     v = getattr(self.bus, sig).value
-                    v.binstr = 'x'*len(v)
+                    v = apply_binstr(v, 'x'*len(v))
                     getattr(self.bus, sig).setimmediatevalue(v)
 
         if hasattr(self.bus, "tkeep"):

--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -30,7 +30,7 @@ from cocotb.triggers import RisingEdge, Timer, First, Event
 from cocotb.utils import get_sim_time
 from cocotb_bus.bus import Bus
 
-from .compat import apply_binstr
+from .compat import apply_binstr, set_event
 from .version import __version__
 from .reset import Reset
 
@@ -158,7 +158,7 @@ class AxiStreamFrame:
 
     def handle_tx_complete(self):
         if isinstance(self.tx_complete, Event):
-            self.tx_complete.set(self)
+            set_event(self.tx_completeself)
         elif callable(self.tx_complete):
             self.tx_complete(self)
 
@@ -284,7 +284,7 @@ class AxiStreamBase(Reset):
         self.dequeue_event = Event()
         self.current_frame = None
         self.idle_event = Event()
-        self.idle_event.set()
+        set_event(self.idle_event)
         self.active_event = Event()
         self.wake_event = Event()
 
@@ -351,8 +351,8 @@ class AxiStreamBase(Reset):
             frame = self.queue.get_nowait()
             frame.sim_time_end = None
             frame.handle_tx_complete()
-        self.dequeue_event.set()
-        self.idle_event.set()
+        set_event(self.dequeue_event)
+        set_event(self.idle_event)
         self.active_event.clear()
         self.queue_occupancy_bytes = 0
         self.queue_occupancy_frames = 0
@@ -367,7 +367,7 @@ class AxiStreamBase(Reset):
             self.active = False
 
             if self.queue.empty():
-                self.idle_event.set()
+                set_event(self.idle_event)
         else:
             self.log.info("Reset de-asserted")
             if self._run_cr is None:
@@ -443,7 +443,7 @@ class AxiStreamSource(AxiStreamBase, AxiStreamPause):
         frame = AxiStreamFrame(frame)
         await self.queue.put(frame)
         self.idle_event.clear()
-        self.active_event.set()
+        set_event(self.active_event)
         self.queue_occupancy_bytes += len(frame)
         self.queue_occupancy_frames += 1
 
@@ -453,7 +453,7 @@ class AxiStreamSource(AxiStreamBase, AxiStreamPause):
         frame = AxiStreamFrame(frame)
         self.queue.put_nowait(frame)
         self.idle_event.clear()
-        self.active_event.set()
+        set_event(self.active_event)
         self.queue_occupancy_bytes += len(frame)
         self.queue_occupancy_frames += 1
 
@@ -525,7 +525,7 @@ class AxiStreamSource(AxiStreamBase, AxiStreamPause):
             if (tready_sample and tvalid_sample) or not tvalid_sample:
                 if not frame and not self.queue.empty():
                     frame = self.queue.get_nowait()
-                    self.dequeue_event.set()
+                    set_event(self.dequeue_event)
                     self.queue_occupancy_bytes -= len(frame)
                     self.queue_occupancy_frames -= 1
                     self.current_frame = frame
@@ -580,7 +580,7 @@ class AxiStreamSource(AxiStreamBase, AxiStreamPause):
                         self.bus.tlast.value = 0
                     self.active = bool(frame)
                     if not frame and self.queue.empty():
-                        self.idle_event.set()
+                        set_event(self.idle_event)
                         self.active_event.clear()
 
                         await self.active_event.wait()
@@ -660,14 +660,14 @@ class AxiStreamMonitor(AxiStreamBase):
 
         while True:
             await event
-            self.wake_event.set()
+            set_event(self.wake_event)
 
     async def _run_tready_monitor(self):
         event = RisingEdge(self.bus.tready)
 
         while True:
             await event
-            self.wake_event.set()
+            set_event(self.wake_event)
 
     async def _run(self):
         frame = None
@@ -720,7 +720,7 @@ class AxiStreamMonitor(AxiStreamBase):
                     self.queue_occupancy_frames += 1
 
                     self.queue.put_nowait(frame)
-                    self.active_event.set()
+                    set_event(self.active_event)
 
                     frame = None
             else:
@@ -763,10 +763,10 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
                 self.bus.tready.value = 0
 
     def _pause_update(self, val):
-        self.wake_event.set()
+        set_event(self.wake_event)
 
     def _dequeue(self, frame):
-        self.wake_event.set()
+        set_event(self.wake_event)
 
     async def _run(self):
         frame = None
@@ -821,7 +821,7 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
                     self.queue_occupancy_frames += 1
 
                     self.queue.put_nowait(frame)
-                    self.active_event.set()
+                    set_event(self.active_event)
 
                     frame = None
             else:

--- a/cocotbext/axi/compat.py
+++ b/cocotbext/axi/compat.py
@@ -32,7 +32,15 @@ if cocotb_2x_or_newer:
     def apply_binstr(value, binstr):
         return LogicArray(binstr, range=value.range)
 
+    def set_event(event, data=None):
+        # Data needs to be set before
+        event.data = data
+        event.set()
+
 else:
     def apply_binstr(value, binstr):
         value.binstr = binstr
         return value
+
+    def set_event(event, data=None):
+        event.set(data)

--- a/cocotbext/axi/compat.py
+++ b/cocotbext/axi/compat.py
@@ -1,0 +1,38 @@
+"""
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"""
+
+from packaging.version import parse as parse_version
+import cocotb
+
+# Use 1.999.0 in comparison to match pre-release versions of cocotb too
+cocotb_2x_or_newer = parse_version(cocotb.__version__) > parse_version("1.999.0")
+
+if cocotb_2x_or_newer:
+    from cocotb.types import LogicArray
+
+    def apply_binstr(value, binstr):
+        return LogicArray(binstr, range=value.range)
+
+else:
+    def apply_binstr(value, binstr):
+        value.binstr = binstr
+        return value

--- a/cocotbext/axi/reset.py
+++ b/cocotbext/axi/reset.py
@@ -56,7 +56,7 @@ class Reset:
 
     async def _run_reset(self, reset_signal, active_level):
         while True:
-            if bool(reset_signal.value):
+            if str(reset_signal.value) == '1':
                 await FallingEdge(reset_signal)
                 self._ext_reset = not active_level
                 self._update_reset()

--- a/cocotbext/axi/stream.py
+++ b/cocotbext/axi/stream.py
@@ -29,6 +29,7 @@ from cocotb.queue import Queue, QueueFull
 from cocotb.triggers import RisingEdge, Event, First, Timer
 from cocotb_bus.bus import Bus
 
+from .compat import apply_binstr
 from .reset import Reset
 
 
@@ -120,7 +121,7 @@ class StreamBase(Reset):
                     assert len(getattr(self.bus, sig)) == self._signal_widths[sig]
                 if self._init_x and sig not in (self._valid_signal, self._ready_signal):
                     v = getattr(self.bus, sig).value
-                    v.binstr = 'x'*len(v)
+                    v = apply_binstr(v, 'x'*len(v))
                     getattr(self.bus, sig).setimmediatevalue(v)
 
         self._run_cr = None

--- a/cocotbext/axi/stream.py
+++ b/cocotbext/axi/stream.py
@@ -259,8 +259,8 @@ class StreamSource(StreamBase, StreamPause):
             await clock_edge_event
 
             # read handshake signals
-            ready_sample = not has_ready or self.ready.value
-            valid_sample = not has_valid or self.valid.value
+            ready_sample = not has_ready or str(self.ready.value) == '1'
+            valid_sample = not has_valid or str(self.valid.value) == '1'
 
             if (ready_sample and valid_sample) or (not valid_sample):
                 if not self.queue.empty() and not self.pause:
@@ -346,8 +346,8 @@ class StreamMonitor(StreamBase):
             await clock_edge_event
 
             # read handshake signals
-            ready_sample = not has_ready or self.ready.value
-            valid_sample = not has_valid or self.valid.value
+            ready_sample = not has_ready or str(self.ready.value) == '1'
+            valid_sample = not has_valid or str(self.valid.value) == '1'
 
             if ready_sample and valid_sample:
                 obj = self._transaction_obj()
@@ -404,8 +404,8 @@ class StreamSink(StreamMonitor, StreamPause):
             await clock_edge_event
 
             # read handshake signals
-            ready_sample = not has_ready or self.ready.value
-            valid_sample = not has_valid or self.valid.value
+            ready_sample = not has_ready or str(self.ready.value) == '1'
+            valid_sample = not has_valid or str(self.valid.value) == '1'
 
             if ready_sample and valid_sample:
                 obj = self._transaction_obj()

--- a/tests/axi/test_axi.py
+++ b/tests/axi/test_axi.py
@@ -296,7 +296,7 @@ def cycle_pause():
     return itertools.cycle([1, 1, 1, 0])
 
 
-if cocotb.SIM_NAME:
+if hasattr(cocotb, 'SIM_NAME') and cocotb.SIM_NAME:
 
     data_width = len(cocotb.top.axi_wdata)
     byte_lanes = data_width // 8

--- a/tests/axil/test_axil.py
+++ b/tests/axil/test_axil.py
@@ -285,7 +285,7 @@ def cycle_pause():
     return itertools.cycle([1, 1, 1, 0])
 
 
-if cocotb.SIM_NAME:
+if hasattr(cocotb, 'SIM_NAME') and cocotb.SIM_NAME:
 
     for test in [run_test_write, run_test_read]:
 

--- a/tests/axis/test_axis.py
+++ b/tests/axis/test_axis.py
@@ -135,7 +135,7 @@ def incrementing_payload(length):
     return bytearray(itertools.islice(itertools.cycle(range(256)), length))
 
 
-if cocotb.SIM_NAME:
+if hasattr(cocotb, 'SIM_NAME') and cocotb.SIM_NAME:
 
     factory = TestFactory(run_test)
     factory.add_option("payload_lengths", [size_list])


### PR DESCRIPTION
This PR adds support for upcoming cocotb 2.0 release in a way that both cocotb 1.x and cocotb 2.x can be supported with minimal maintenance overhead.

In order to test with cocotb master, the following patch needs to be applied to pick newer dependencies:

```
diff --git a/setup.cfg b/setup.cfg
index 8fa9aa2..500b4b7 100644
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,9 +68,9 @@ usedevelop = True
 deps =
     pytest == 7.2.1
     pytest-xdist == 3.1.0
-    cocotb == 1.7.2
-    cocotb-bus == 0.2.1
-    cocotb-test == 0.2.4
+    cocotb @git+https://github.com/cocotb/cocotb@828d127e8e865fc2ecf4979ea54767e1da80dd21
+    cocotb-bus @git+https://github.com/p12tic/cocotb-bus@cocotb-2.0-compat
+    cocotb-test @git+https://github.com/p12tic/cocotb-test@cocotb-2.0
     coverage == 7.0.5
     pytest-cov == 4.0.0
 ```
