### PR TITLE
wstrb is not an optional AXI signal

### DIFF
--- a/cocotbext/axi/axil_channels.py
+++ b/cocotbext/axi/axil_channels.py
@@ -33,8 +33,8 @@ AxiLiteAWBus, AxiLiteAWTransaction, AxiLiteAWSource, AxiLiteAWSink, AxiLiteAWMon
 
 # Write data channel
 AxiLiteWBus, AxiLiteWTransaction, AxiLiteWSource, AxiLiteWSink, AxiLiteWMonitor = define_stream("AxiLiteW",
-    signals=["wdata", "wvalid", "wready"],
-    optional_signals=["wstrb"]
+    signals=["wdata", "wvalid", "wready", "wstrb"],
+    optional_signals=[]
 )
 
 # Write response channel


### PR DESCRIPTION
`wstrb` is a required signal in both AXI (Table A2-3 of the AXI4 Spec) and AXI-Lite (Table B1-1). This is a small update to AxiLiteW bus to reflect that.