### PR TITLE
axis.py: Add clean() method to the AxiStreamSink

### DIFF
--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -746,6 +746,10 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
 
         super().__init__(bus, clock, reset, reset_active_level, byte_size, byte_lanes, *args, **kwargs)
 
+    def clear(self):
+        while not self.empty():
+            self.recv_nowait()
+    
     def full(self):
         if self.queue_occupancy_limit_bytes > 0 and self.queue_occupancy_bytes > self.queue_occupancy_limit_bytes:
             return True


### PR DESCRIPTION
During more complex testing scenario where I have multiple test factories, I came across a bug.
If the tests from the first factory have ended with some frames not received by the TB (because eg. that interface was ignored in prior tests), in the first few tests from the next factory the Sink was receiving ghost frames from the prior tests even if there was no valid data on the bus.

The simplest workaround for this is to clear all Sinks at the end of each test.