### PR TITLE
When a signal is missing print the signal name instead of the default … AttributeError None type...

### DIFF
--- a/cocotbext/axi/stream.py
+++ b/cocotbext/axi/stream.py
@@ -124,12 +124,15 @@ class StreamBase(Reset):
                 if sig in self._signal_widths:
                     assert len(getattr(self.bus, sig)) == self._signal_widths[sig]
                 if self._init_x and sig not in (self._valid_signal, self._ready_signal):
-                    s = getattr(self.bus, sig)
                     try:
+                        s = getattr(self.bus, sig)
                         v = LogicArray("x"*len(s.value))
                     except NameError:
                         v = s.value
                         v.binstr = 'x'*len(v)
+                    except AttributeError:
+                        self.log.fatal(f"signal {sig} does not exist")
+                        raise
                     s.setimmediatevalue(v)
 
         self._run_cr = None


### PR DESCRIPTION
The current code prints
```
                                                        AttributeError: 'NoneType' object has no attribute 'value'
```
when it is not able to find a signal, The message has no information on which signal is missing. The patch prints
```
     0.00ns CRITICAL cocotb.tb.                         signal rid does not exist
...
                                                        AttributeError: 'NoneType' object has no attribute 'value'
```
which aids in debug.

PS: there might be other places where sinilar try,catch block might be required... My RTL hit this case.