### PR TITLE
Print slave read and write callback exceptions

### DIFF
--- a/cocotbext/axi/axi_slave.py
+++ b/cocotbext/axi/axi_slave.py
@@ -187,8 +187,8 @@ class AxiSlaveWrite(Reset):
                 try:
                     for addr, data in write_ops:
                         await self._write(addr, data)
-                except Exception:
-                    self.log.warning("Write operation failed")
+                except Exception as e:
+                    self.log.warning(f"Write operation failed: {e}")
                     b.bresp = AxiResp.SLVERR
 
                 assert last == (n == length-1)
@@ -315,8 +315,8 @@ class AxiSlaveRead(Reset):
 
                 try:
                     data = await self._read(cur_word_addr, self.byte_lanes)
-                except Exception:
-                    self.log.warning("Read operation failed")
+                except Exception as e:
+                    self.log.warning(f"Read operation failed: {e}")
                     data = bytes(self.byte_lanes)
                     r.rresp = AxiResp.SLVERR
 

--- a/cocotbext/axi/axil_slave.py
+++ b/cocotbext/axi/axil_slave.py
@@ -151,8 +151,8 @@ class AxiLiteSlaveWrite(Reset):
             try:
                 for addr, data in write_ops:
                     await self._write(addr, data)
-            except Exception:
-                self.log.warning("Write operation failed")
+            except Exception as e:
+                self.log.warning(f"Write operation failed: {e}")
                 b.bresp = AxiResp.SLVERR
 
             await self.b_channel.send(b)
@@ -234,8 +234,8 @@ class AxiLiteSlaveRead(Reset):
 
             try:
                 data = await self._read(addr, self.byte_lanes)
-            except Exception:
-                self.log.warning("Read operation failed")
+            except Exception as e:
+                self.log.warning(f"Read operation failed: {e}")
                 data = bytes(self.byte_lanes)
                 r.rresp = AxiResp.SLVERR
 


### PR DESCRIPTION
It would be much easier to debug callbacks code with exception text printing. For example via `raise ValueError("Some info...")` it's possible to pass some info about the error

Resolves https://github.com/alexforencich/cocotbext-axi/issues/105