### PR TITLE
Allow metavalues in tdata bits for which tkeep is 0

### DIFF
--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -710,7 +710,12 @@ class AxiStreamMonitor(AxiStreamBase):
                     self.active = True
 
                 for offset in range(self.byte_lanes):
-                    frame.tdata.append((int(self.bus.tdata.value) >> (offset * self.byte_size)) & self.byte_mask)
+                    keep_mask = LogicArray("1"*self.width)
+                    if has_tkeep:
+                        for i in range(self.byte_lanes):
+                            for j in range(8):
+                                keep_mask[i*8 + j] = self.bus.tkeep.value[i]
+                    frame.tdata.append((int(self.bus.tdata.value & keep_mask) >> (offset * self.byte_size)) & self.byte_mask)
                     if has_tkeep:
                         frame.tkeep.append((int(self.bus.tkeep.value) >> offset) & 1)
                     if has_tid:
@@ -811,7 +816,12 @@ class AxiStreamSink(AxiStreamMonitor, AxiStreamPause):
                     self.active = True
 
                 for offset in range(self.byte_lanes):
-                    frame.tdata.append((int(self.bus.tdata.value) >> (offset * self.byte_size)) & self.byte_mask)
+                    keep_mask = LogicArray("1"*self.width)
+                    if has_tkeep:
+                        for i in range(self.byte_lanes):
+                            for j in range(8):
+                                keep_mask[i*8 + j] = self.bus.tkeep.value[i]
+                    frame.tdata.append((int(self.bus.tdata.value & keep_mask) >> (offset * self.byte_size)) & self.byte_mask)
                     if has_tkeep:
                         frame.tkeep.append((int(self.bus.tkeep.value) >> offset) & 1)
                     if has_tid:


### PR DESCRIPTION
Sets tdata bits where tkeep is '0' to '0' before the integer conversion.

## Why is this interesting?

When tkeep is '0', the corresponding data byte value ignored.
In VHDL designs, it may be interesting to set the value to '-' (don't care) when generating a tkeep 0, which matches the design intent and allows synthesis to chose the optimal value for performance.

However, with the previous logic in cocotbext-axi, the whole tdata vector is converted to an integer before extracting individual bytes.
Converting a LogicArray with any non 0/1 values to an int causes an exception and thus testcase failure.

This PR adds logic, that zeroes the data vector for bytes where tkeep is '0', if tkeep is enabled to work around this failure case.

