### PR TITLE
Update axis.py - tvalid / tdata sampling mismatch of AxiStreamMonitor

### DIFF
--- a/cocotbext/axi/axis.py
+++ b/cocotbext/axi/axis.py
@@ -695,6 +695,7 @@ class AxiStreamMonitor(AxiStreamBase):
 
         while True:
             await clock_edge_event
+            await cocotb.triggers.ReadOnly()
 
             # read handshake signals
             tready_sample = (not has_tready) or self.bus.tready.value


### PR DESCRIPTION
bugfix to avoid sampling tdata to early. In my case the previous tdata was sampled when tvalid rising edge occurs and not the updated tdata together with tvalid.